### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Interactive visualization of the number of seats of possible coalitions in Dutch parliament, according to poll aggregates from [Peilingwijzer](https://peilingwijzer.tomlouwerse.nl).
 
-Try out the Voilà app hosted on Heroku: [![Voila](https://img.shields.io/badge/launch-voil%C3%A0-5DBCAF)](https://fast-earth-66481.herokuapp.com/)
+Try out the Voilà app hosted on Heroku: [![Voila](https://img.shields.io/badge/launch-voil%C3%A0-5DBCAF)](https://coalitiewijzer.herokuapp.com/)
 
 Try out the notebooks on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/egpbos/coalitiewijzer/main)


### PR DESCRIPTION
Very minor fix: the Voilá badge in `README.md` was pointing to the wrong place.